### PR TITLE
Fixed: Wrong value for `main` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
     "type": "git",
     "url": "https://github.com/laktek/extract-values.git"
   },
-  "main": "./lib/extract_values.js"
+  "main": "./extract_values.js"
 }


### PR DESCRIPTION
Because the value of the `main`-property in `package.json` was pointing to a non-existing path, Node.js wasn’t able to find the correct location of the `extract-values.js` file.
