### PR TITLE
Allow exact string matches to return an empty object instead of null

### DIFF
--- a/extract_values.js
+++ b/extract_values.js
@@ -30,6 +30,11 @@
 		if (!matches) {
 			return null;
 		}
+		
+    // Allow exact string matches to return an empty object instead of null
+    if (!tokens) {
+      return (str == pattern) ? {} : null
+    }
 
 		matches = matches.splice(1);
 		var output = {};

--- a/tests.js
+++ b/tests.js
@@ -24,8 +24,11 @@ var cases = [
 
 	[["4th October  to 10th  October", "from `from` to `to`", { whitespace: 1, delimiters: ["`", "`"] }], null],
 
-	[["Convert 1500 Grams to Kilograms", "convert {quantity} {from_unit} to {to_unit}", { lowercase: true }], {"quantity": "1500", "from_unit": "grams", "to_unit": "kilograms" }]
-
+	[["Convert 1500 Grams to Kilograms", "convert {quantity} {from_unit} to {to_unit}", { lowercase: true }], {"quantity": "1500", "from_unit": "grams", "to_unit": "kilograms" }],
+	
+  [["same thing", "same thing"], {}],
+    
+  [["/app/les", "/app"], null]
 ]
 
 for (var i = 0; i < cases.length; i++) {


### PR DESCRIPTION
We want to be able to iterate over a collection of patterns, some of which don't actually contain values to extract. This patch solves that problem, returning `{}` instead of `null` for exact string matches.

``` coffee
patterns = [
  "/apps"
  "/apps/{app}/resources"
  "/apps/{app}/settings"
  "/addons/{addon}+{plan}"
]
```

cc @max
