### PR TITLE
Trimming whitespace on the key

### DIFF
--- a/extract_values.js
+++ b/extract_values.js
@@ -39,7 +39,7 @@
 		matches = matches.splice(1);
 		var output = {};
 		for (var i=0; i < tokens.length; i++) {
-			output[tokens[i].replace( new RegExp( delimiters[0] + "|" + delimiters[1], "g"), "")] = matches[i];
+			output[tokens[i].replace( new RegExp( delimiters[0] + "|" + delimiters[1], "g"), "").trim()] = matches[i];
 		}
 
 		return output;

--- a/tests.js
+++ b/tests.js
@@ -28,8 +28,13 @@ var cases = [
 
   [["same thing", "same thing"], {}],
 
-  [["/app/les", "/app"], null]
-];
+  [["/app/les", "/app"], null],
+
+  [[
+  "<h1 class=\"p-title\">This is a title.</h1><data class=\"p-name\" value=\"This is a name\"></data>",
+  "<h1 class=\"p-title\"><%= title %></h1><data class=\"p-name\" value=\"<%= name %>\"></data>",
+  { delimiters: ["<%=","%>"]}],{ title: 'This is a title.', name:'This is a name'}
+  ]];
 
 for (var i = 0; i < cases.length; i++) {
   assert.deepEqual(extract_values.apply(this, cases[i][0]), cases[i][1]);


### PR DESCRIPTION
In some token formats, we like to leave extra spaces for readability...so adding a trim function to the output keys to remove any of these extra spaces.
